### PR TITLE
Implement dynamic CSV and JSON paths

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -10,9 +10,11 @@ from .test_generator import generate_tests_json
 def get_configuration() -> config.Config:
     input_csv = request_file_name(config.env_path())
     project_key = input('Clave de proyecto por defecto: ').strip()
-    endpoint_url = os.getenv('XRAY_IMPORT_URL', 'https://xray.cloud.getxray.app/api/v1/import/test/bulk')
+    endpoint_url = os.getenv('XRAY_IMPORT_URL',
+                            'https://xray.cloud.getxray.app/api/v1/import/test/bulk')
     token = get_token()
-    output_json = f"{os.path.splitext(input_csv)[0]}.json"
+    output_json = os.path.join(
+        config.json_path(), f"{os.path.splitext(input_csv)[0]}.json")
     return config.Config(input_csv, project_key, token, endpoint_url, output_json)
 
 
@@ -32,14 +34,16 @@ def interactive_menu():
 
         if choice == '1':
             cfg.input_csv = request_file_name(config.env_path())
-            cfg.output_json = f"{os.path.splitext(cfg.input_csv)[0]}.json"
+            cfg.output_json = os.path.join(
+                config.json_path(), f"{os.path.splitext(cfg.input_csv)[0]}.json")
         elif choice == '2':
             cfg.project_key = input('Nueva project key: ').strip()
         elif choice == '3':
             cfg.token = get_token()
             print('Token actualizado.')
         elif choice == '4':
-            generate_tests_json(cfg.input_csv, cfg.project_key, cfg.output_json)
+            csv_path = os.path.join(config.env_path(), cfg.input_csv)
+            generate_tests_json(csv_path, cfg.project_key, cfg.output_json)
         elif choice == '5':
             send_json_to_xray(cfg.output_json, cfg.token, cfg.endpoint_url)
         elif choice == '6':

--- a/src/config.py
+++ b/src/config.py
@@ -16,3 +16,10 @@ class Config:
 
 def env_path() -> str:
     return os.getenv('PATH_FILES', '.')
+
+
+def json_path() -> str:
+    """Return path for generated JSON files ensuring it exists."""
+    path = os.path.join(env_path(), 'json')
+    os.makedirs(path, exist_ok=True)
+    return path

--- a/src/utils.py
+++ b/src/utils.py
@@ -31,4 +31,4 @@ def request_file_name(path_env: str) -> str:
         input_file = os.path.join(path_env, f'{file_name}.csv')
         if verify_existing_file(input_file):
             break
-    return input_file
+    return f'{file_name}.csv'


### PR DESCRIPTION
## Summary
- create a `json_path` helper in config to store generated JSON files in `json/`
- update the CLI to keep only the CSV filename and write JSONs to the new folder
- adjust `request_file_name` to return only the filename

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*