### PR TITLE
Restore CSV separator option and enforce project key

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -24,7 +24,7 @@ from .services import (
 def get_configuration() -> config.Config:
     """Return initial configuration without requesting a CSV file."""
     while True:
-        project_key = input('Clave de proyecto por defecto [DUDBQ]: ').strip()
+        project_key = input('Clave de proyecto por defecto: ').strip()
         if project_key:
             break
         print('Debe ingresar la clave de proyecto.')
@@ -71,25 +71,29 @@ def csv_menu(cfg: config.Config) -> None:
     """Handle CSV related actions."""
     while True:
         print('\n--- Gestión de Archivos CSV ---')
-        print('1. Convertir CSV a JSON')
-        print('2. Convertir CSV a JSON en lote')
-        print('3. Listar archivos CSV')
+        print(f"1. Cambiar separador CSV (actual: {cfg.csv_separator})")
+        print('2. Convertir CSV a JSON')
+        print('3. Convertir CSV a JSON en lote')
+        print('4. Listar archivos CSV')
         print('0. Volver')
         opt = input('Seleccione una opción: ').strip()
 
         if opt == '1':
+            new_sep = input('Nuevo separador (, o ;): ').strip()
+            cfg.csv_separator = ';' if new_sep == ';' else ','
+        elif opt == '2':
             csv_name = request_file_name(config.env_path())
             csv_path = os.path.join(config.env_path(), csv_name)
             json_out = os.path.join(config.json_path(), f"{os.path.splitext(csv_name)[0]}.json")
-            generate_tests_json(csv_path, cfg.project_key, json_out)
-        elif opt == '2':
+            generate_tests_json(csv_path, cfg.project_key, json_out, cfg.csv_separator)
+        elif opt == '3':
             csv_dir = config.env_path()
             json_dir = config.json_path()
-            successes, failures = generate_jsons_from_csvs(csv_dir, cfg.project_key, json_dir)
+            successes, failures = generate_jsons_from_csvs(csv_dir, cfg.project_key, json_dir, cfg.csv_separator)
             print(f'Conversión completada. Éxitos: {len(successes)} - Fallos: {len(failures)}')
             for fpath, reason in failures:
                 print(f"Falló {os.path.basename(fpath)}: {reason}")
-        elif opt == '3':
+        elif opt == '4':
             list_files(config.env_path(), ('.csv',))
         elif opt == '0':
             break

--- a/src/config.py
+++ b/src/config.py
@@ -12,6 +12,7 @@ class Config:
     token: str
     endpoint_url: str
     output_json: str
+    csv_separator: str = os.getenv('CSV_SEPARATOR', ',')
 
 
 def env_path() -> str:

--- a/src/services/conversion.py
+++ b/src/services/conversion.py
@@ -8,14 +8,28 @@ import re
 from .cleanup import clean_json_data
 
 
-def generate_tests_json(input_csv: str, project_key: str, output_json: str):
+def generate_tests_json(
+    input_csv: str, project_key: str, output_json: str, sep: str = ','
+) -> list[dict]:
     """Convert a CSV test specification to an Xray-compatible JSON file."""
-    df = (
-        pd.read_csv(input_csv, dtype=str, encoding='utf-8', sep=',', skipinitialspace=True)
-        .fillna('')
-    )
+    try:
+        df = pd.read_csv(
+            input_csv,
+            dtype=str,
+            encoding='utf-8',
+            sep=sep,
+            skipinitialspace=True,
+        ).fillna('')
+    except Exception as exc:  # pragma: no cover - runtime errors only
+        raise ValueError(f'No se pudo leer CSV {input_csv}: {exc}')
     df = df.dropna(how='all')
     df.columns = df.columns.str.strip()
+
+    required = {'Summary', 'Step'}
+    if not required.issubset(df.columns):
+        raise ValueError(
+            'El CSV no contiene las columnas requeridas o el separador es incorrecto'
+        )
 
     if 'Test ID' not in df.columns:
         df['Test ID'] = df.groupby('Summary').ngroup()
@@ -62,7 +76,9 @@ def generate_tests_json(input_csv: str, project_key: str, output_json: str):
     return tests
 
 
-def generate_jsons_from_csvs(csv_dir: str, project_key: str, json_dir: str):
+def generate_jsons_from_csvs(
+    csv_dir: str, project_key: str, json_dir: str, sep: str = ','
+) -> tuple[list[str], list[tuple[str, str]]]:
     """Convert all CSV files in *csv_dir* to JSON format in *json_dir*."""
     successes: list[str] = []
     failures: list[tuple[str, str]] = []
@@ -73,7 +89,7 @@ def generate_jsons_from_csvs(csv_dir: str, project_key: str, json_dir: str):
         json_name = f"{os.path.splitext(name)[0]}.json"
         json_path = os.path.join(json_dir, json_name)
         try:
-            generate_tests_json(csv_path, project_key, json_path)
+            generate_tests_json(csv_path, project_key, json_path, sep)
             successes.append(csv_path)
         except Exception as exc:  # pragma: no cover - runtime errors only
             failures.append((csv_path, str(exc)))
@@ -91,8 +107,7 @@ def excels_to_csvs(excel_dir: str, csv_dir: str):
         csv_name = f"{os.path.splitext(name)[0]}.csv"
         csv_path = os.path.join(csv_dir, csv_name)
         try:
-            df = pd.read_excel(excel_path, dtype=str).fillna('')
-            df.to_csv(csv_path, index=False, encoding='utf-8')
+            excel_to_csv(excel_path, csv_path)
             successes.append(csv_path)
         except Exception as exc:  # pragma: no cover - runtime errors only
             failures.append((excel_path, str(exc)))
@@ -101,7 +116,10 @@ def excels_to_csvs(excel_dir: str, csv_dir: str):
 
 def excel_to_csv(excel_path: str, csv_path: str):
     """Convert a single Excel file to CSV."""
-    df = pd.read_excel(excel_path, dtype=str).fillna('')
-    df.to_csv(csv_path, index=False, encoding='utf-8')
+    try:
+        df = pd.read_excel(excel_path, dtype=str).fillna('')
+        df.to_csv(csv_path, index=False, encoding='utf-8')
+    except Exception as exc:  # pragma: no cover - runtime errors only
+        raise ValueError(f'Error al convertir {excel_path}: {exc}')
     print(f"Generado '{csv_path}' desde '{excel_path}'.")
     return csv_path


### PR DESCRIPTION
## Summary
- enforce entering project key without showing default
- restore ability to choose CSV separator
- reintroduce csv separator option in CSV menu
- handle separator in conversion utilities

## Testing
- `python -m py_compile $(git ls-files '*.py')`