### PR TITLE
Refactor: import Xray tests directly from Excel

### DIFF
--- a/src/services/__init__.py
+++ b/src/services/__init__.py
@@ -5,6 +5,7 @@ from .conversion import (
     excels_to_csvs,
     excel_to_csv,
 )
+from .excel_import import tests_from_excel, send_excel_to_xray
 from .xray_client import XrayClient
 from .cleanup import (
     clean_json_data,
@@ -18,6 +19,8 @@ __all__ = [
     'excels_to_csvs',
     'excel_to_csv',
     'XrayClient',
+    'tests_from_excel',
+    'send_excel_to_xray',
     'clean_json_data',
     'clean_json_file',
     'clean_json_directory',

--- a/src/services/excel_import.py
+++ b/src/services/excel_import.py
@@ -1,0 +1,93 @@
+"""Read Excel test specs and send them to Xray."""
+from __future__ import annotations
+
+from pathlib import Path
+import re
+from typing import List, Tuple
+
+import pandas as pd
+
+from .cleanup import clean_json_data
+from .xray_client import XrayClient
+
+
+_COLUMNS = [
+    "Test ID",
+    "Summary",
+    "Description",
+    "Step",
+    "Data",
+    "Expected Result",
+]
+
+
+def _read_excel(path: str) -> pd.DataFrame:
+    """Return DataFrame from Excel *path* assuming no headers."""
+    df = pd.read_excel(path, header=None, dtype=str).fillna("")
+    df = df.iloc[:, : len(_COLUMNS)]
+    df.columns = _COLUMNS[: df.shape[1]]
+    return df
+
+
+def _split_tests(df: pd.DataFrame) -> list[pd.DataFrame]:
+    """Split DataFrame into tests whenever "Test ID" restarts at 1."""
+    groups: list[pd.DataFrame] = []
+    start = 0
+    for idx in range(1, len(df)):
+        if str(df.at[idx, "Test ID"]).strip() == "1":
+            groups.append(df.iloc[start:idx])
+            start = idx
+    groups.append(df.iloc[start:])
+    return groups
+
+
+def tests_from_excel(excel_path: str, project_key: str) -> list[dict]:
+    """Parse *excel_path* and return a list of test payloads."""
+    df = _read_excel(excel_path)
+    folders = [f"HU-{num}" for num in re.findall(r"\d+", Path(excel_path).stem)]
+    groups = _split_tests(df)
+
+    tests: list[dict] = []
+    for i, group in enumerate(groups):
+        first = group.iloc[0]
+        folder = folders[i] if i < len(folders) else ""
+        test = {
+            "testtype": "Manual",
+            "xray_test_repository_folder": folder,
+            "fields": {
+                "project": {"key": project_key},
+                "summary": first.get("Summary", ""),
+                "description": first.get("Description", ""),
+            },
+            "steps": [],
+        }
+        for _, row in group.iterrows():
+            test["steps"].append(
+                {
+                    "action": row.get("Step", ""),
+                    "data": row.get("Data", ""),
+                    "result": row.get("Expected Result", ""),
+                }
+            )
+        tests.append(test)
+
+    clean_json_data(tests)
+    return tests
+
+
+def send_excel_to_xray(
+    excel_path: str, project_key: str, client: XrayClient
+) -> Tuple[List[int], List[Tuple[int, str]]]:
+    """Send tests defined in *excel_path* to Xray using *client*."""
+    tests = tests_from_excel(excel_path, project_key)
+    successes: list[int] = []
+    failures: list[Tuple[int, str]] = []
+
+    for idx, test in enumerate(tests, start=1):
+        try:
+            client.send_tests([test])
+            successes.append(idx)
+        except Exception as exc:  # pragma: no cover - runtime errors only
+            failures.append((idx, str(exc)))
+
+    return successes, failures

--- a/src/services/xray_client.py
+++ b/src/services/xray_client.py
@@ -81,6 +81,30 @@ class XrayClient:
             raise requests.HTTPError(f"{exc}: {detail}", response=resp) from None
         return resp
 
+    def send_tests(self, tests: list[dict], *, session: requests.Session | None = None):
+        """Send a list of test objects directly to Xray."""
+        json_body = json.dumps(tests, ensure_ascii=False).encode("utf-8")
+        headers = {
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {self.token}",
+        }
+        sess = session or self._session
+        resp = sess.post(self.endpoint_url, headers=headers, data=json_body)
+        try:
+            resp.raise_for_status()
+        except requests.HTTPError as exc:
+            detail = ""
+            try:
+                data = resp.json()
+                if isinstance(data, dict):
+                    detail = data.get("error") or data.get("message") or str(data)
+                else:
+                    detail = str(data)
+            except ValueError:
+                detail = resp.text.strip()
+            raise requests.HTTPError(f"{exc}: {detail}", response=resp) from None
+        return resp
+
     def send_multiple(
         self,
         json_files: list[str],


### PR DESCRIPTION
## Summary
- add new `excel_import` service to parse Excel files without headers
- include dynamic repository folder detection and Xray upload
- extend `XrayClient` with `send_tests` for direct payload uploads
- expose new functions via the service package

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_b_684f8f10cccc83209a3fe72945431368